### PR TITLE
fixed 'dict object' has no attribute 'services'

### DIFF
--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -22,7 +22,8 @@
 
 - name: Wait for fio benchmark to complete its execution
   ansible.builtin.service_facts:
-  until: ansible_facts.services is defined and ansible_facts.services['fio.service']['state'] != "running"
+  register: services_state
+  until: services-state.ansible_facts.services is defined and services_state.ansible_facts.services['fio.service'].state != "running"
   retries: "{{ fiotest_retry_attempt }}"
   delay: "{{ fiotest_retry_delay }}"
 

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -23,7 +23,7 @@
 - name: Wait for fio benchmark to complete its execution
   ansible.builtin.service_facts:
   register: services_state
-  until: services-state.ansible_facts.services is defined and services_state.ansible_facts.services['fio.service'].state != "running"
+  until: services_state.ansible_facts.services is defined and services_state.ansible_facts.services['fio.service'].state != "running"
   retries: "{{ fiotest_retry_attempt }}"
   delay: "{{ fiotest_retry_delay }}"
 


### PR DESCRIPTION
Fixed issue where we keep waiting after service is finished. Using a register to store services state
ref: https://github.com/ansible/ansible/issues/44520