### PR TITLE
Make it possible to fetch raw log files after the test

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ Check `fio_benchmark.yaml` for example on how to run the playbook.
 * `fiotest_rw_throughput_iodepth` - How many IOs it issues to the OS at any given time
    - variable type: integer
 
+* `fio_store_local_logs_dir` - Set this to directory local on a Ansible controller node if you want to fetch test logs there
+   - variable type: string
+
 
 ### Default variables
 
@@ -65,6 +68,9 @@ Check `fio_benchmark.yaml` for example on how to run the playbook.
 # fio benchmark parameters for write/read throughput and write/read iops of a disk on running instance
 fiotest_directory: '/root/fiotest'
 fiotest_rounds: 5
+
+# By default, do not collect logs
+fio_store_local_logs_dir: ''
 
 fiotest_rw_throughput:
 - name: 'write_throughput'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,9 @@
 fio_script_file: '/tmp/run-fio.sh'
 fio_service_file: '/etc/systemd/system/fio.service'
 
+# By default, do not collect logs
+fio_store_local_logs_dir: ''
+
 # fio benchmark parameters for read/write throughput and read/write iops of a disk on running instance
 fiotest_rw_throughput:
 - name: 'write_throughput'

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -63,3 +63,39 @@
 - name: Results - Read Throughput of the disk
   debug:
     msg: "{{ shell_fio_read_throughput.stdout_lines }}"
+
+- name: Show local direcotry we will be fetching to
+  ansible.builtin.debug:
+    var: fio_store_local_logs_dir
+  run_once: yes
+  when: "fio_store_local_logs_dir|length != 0"
+
+- name: Cleanup local direcotry we will be fetching to
+  ansible.builtin.file:
+    path: "{{ fio_store_local_logs_dir }}"
+    state: absent
+  delegate_to: localhost
+  run_once: yes
+  when: "fio_store_local_logs_dir|length != 0"
+
+- name: Find logs we are going to fetch
+  ansible.builtin.find:
+    paths: /tmp
+    depth: 1
+    file_type: file
+    use_regex: no
+    patterns:
+      - fio_benchmark_write_iops_round_*
+      - fio_benchmark_read_iops_round_*
+      - fio_benchmark_write_throughput_round_*
+      - fio_benchmark_read_throughput_round_*
+  when: "fio_store_local_logs_dir|length != 0"
+  register: find_logs
+
+- name: Fetch sosreport tarballs
+  ansible.builtin.fetch:
+    src: "{{ item.path }}"
+    dest: "{{ fio_store_local_logs_dir }}/{{ inventory_hostname }}/"
+    flat: yes
+  when: "fio_store_local_logs_dir|length != 0"
+  loop: "{{ find_logs.files }}"


### PR DESCRIPTION
If you set `fio_store_local_logs_dir`, it will fetch raw log files after the test to the Ansible controller node. By default no log is fetched to preserve original behaviour.